### PR TITLE
Move Cleanup() call to work with Windows

### DIFF
--- a/standard-import/jira-to-lucid-doc/README.md
+++ b/standard-import/jira-to-lucid-doc/README.md
@@ -43,7 +43,8 @@ pip install requests
 * Use the Lucid interface to further analyze and manage these issues conveniently.
 
 ## Configuration and Environment Variables
-This script requires specific environment variables to be set in a `.env` file within the project directory. Create a .env file with the following variables:
+This script requires specific environment variables to be set in a `.env` file within the project directory. Note that the `.env` file must be in the same directory as `jira_to_lucid_doc.py` 
+Create a .env file with the following variables:
 
 * #### JIRA_API_KEY: API key or token for Jira authentication.
 * #### JIRA_AUTH_EMAIL: Email associated with the Jira account.

--- a/standard-import/jira-to-lucid-doc/clients/jira_client.py
+++ b/standard-import/jira-to-lucid-doc/clients/jira_client.py
@@ -1,18 +1,18 @@
 from argparse import Namespace
 from datetime import datetime
+from os import getenv
 from requests import request
 from requests.auth import HTTPBasicAuth
 from typing import List, Dict, Any
-from utils.file_utils import save_raw_issues_to_json, save_parsed_issues_to_csv
 import json
-import os
+from utils.file_utils import save_raw_issues_to_json, save_parsed_issues_to_csv
 
 
 def get_jira_issues(email: str, year: int) -> List[Dict[str, Any]]:
   print("Fetching issues from Jira...")
-  url = f"https://{os.getenv('JIRA_SUBDOMAIN')}.atlassian.net/rest/api/3/search"
+  url = f"https://{getenv('JIRA_SUBDOMAIN')}.atlassian.net/rest/api/3/search"
  
-  auth = HTTPBasicAuth(os.getenv("JIRA_AUTH_EMAIL"), os.getenv("JIRA_API_KEY"))
+  auth = HTTPBasicAuth(getenv("JIRA_AUTH_EMAIL"), getenv("JIRA_API_KEY"))
  
   headers = {
     "Accept": "application/json"

--- a/standard-import/jira-to-lucid-doc/clients/lucid_client.py
+++ b/standard-import/jira-to-lucid-doc/clients/lucid_client.py
@@ -1,9 +1,9 @@
 from argparse import Namespace
-from .jira_client import get_jira_issues, sort_issues_by_quarter
+from os import getenv
 from requests import post
 from typing import Dict, Any
+from .jira_client import get_jira_issues, sort_issues_by_quarter
 from utils.file_utils import cleanup, create_zip_file, generate_json_file
-import os
 
 def create_lucid_board(args: Namespace) -> Dict[str, Any]:
   email = input("Enter the email of your Jira user: ")
@@ -21,7 +21,7 @@ def send_lucid_import_request(email: str, year: int, product: str) -> Dict[str, 
   url = "https://api.lucid.co/documents"
  
   headers = {
-    "Authorization": f'Bearer {os.getenv("LUCID_OAUTH2_TOKEN")}',
+    "Authorization": f'Bearer {getenv("LUCID_OAUTH2_TOKEN")}',
     "Lucid-Api-Version": f"{1}"
   }
 
@@ -35,6 +35,6 @@ def send_lucid_import_request(email: str, year: int, product: str) -> Dict[str, 
   }
   
   response = post(url = url, headers = headers, data = data, files = files)
-  cleanup()
   response.raise_for_status()
+  
   return response.json()

--- a/standard-import/jira-to-lucid-doc/jira_to_lucid_doc.py
+++ b/standard-import/jira-to-lucid-doc/jira_to_lucid_doc.py
@@ -1,10 +1,12 @@
 from dotenv import load_dotenv
 from clients.lucid_client import create_lucid_board
 from utils.arg_utils import parse_args
+from utils.file_utils import cleanup
     
 load_dotenv()
 
 args = parse_args()
 response_json = create_lucid_board(args)
+cleanup()
 
 print(f"Access the new document at: {response_json['editUrl']}")


### PR DESCRIPTION
Ian was running into an error when trying to use the Jira history import where the `Cleanup()` call was saying it couldn’t delete the temporary files used in the import because they were still in use. This PR is to move the `Cleanup()` call so that it happens later in code after the files are certainly done being used.

While I was in there, I also organized some imports.