### PR TITLE
Always set pagination link to not pull duplicate logs

### DIFF
--- a/audit-logs-ingestor/clients/lucidclient.py
+++ b/audit-logs-ingestor/clients/lucidclient.py
@@ -45,7 +45,6 @@ def get_audit_logs(token, connectors):
                 f"{json_count} new audit log events found or identical pagination token. Stopping requests..."
             )
             loop_counter = 0
-            dataaccess.set("link", new_url)
         else:
             logger.info(
                 f"{json_count} new audit log events found. Contining to next page..."
@@ -53,3 +52,6 @@ def get_audit_logs(token, connectors):
             for connector in connectors:
                 connector.store_events(json_data)
             request_url = new_url
+
+        # Always update pagination link to avoid pulling duplicate logs.
+        dataaccess.set("link", new_url)


### PR DESCRIPTION
As is, the pagination link is only set after pulling all Lucid Audit Logs. This approach does not account for network outages, failing services, possible rate limiting from ingesting large amounts of logs, etc. In a failure event where logs did not complete pulling, this script would start pulling logs from the last starting point. This results in unwanted duplicate logs.

Always set the pagination link to avoid pulling duplicate logs in the event that the process does not finish.